### PR TITLE
Incluir Código de Pix na tabela de Equivalência

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ ID	| Forma de pagamento
 24 	| Elo
 25 	| Paypal Internacional
 27 	| Múltiplos Cartões
+32	| PIX
 
 ## Tabela de status de contratos
 


### PR DESCRIPTION
Incluir cód 32 na tabela de equivalência de pagamentos, fazendo referência ao pagamento PIX.